### PR TITLE
fix: add <limits> to long_math.h for std::numeric_limits

### DIFF
--- a/include/slimcpplib/long_math.h
+++ b/include/slimcpplib/long_math.h
@@ -37,6 +37,7 @@
 #include <cstdint>
 
 #include <array>
+#include <limits>
 #include <optional>
 #include <type_traits>
 


### PR DESCRIPTION
long_math.h needs to #include `<limits>` due to its use of `std::numeric_limits<>` :+1: 