### PR TITLE
fix: add intrinsics to header for clang-msvc compilation

### DIFF
--- a/include/slimcpplib/long_math_msvc.h
+++ b/include/slimcpplib/long_math_msvc.h
@@ -1,5 +1,4 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-//
 // Simple Long Integer Math for C++
 // version 1.3
 //
@@ -31,12 +30,20 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-
 #include "long_math.h"
 
 #if defined(_MSC_VER)
+    #include <immintrin.h>
+    #include <intrin.h>
 
-#include <intrin.h>
+    #if defined(__clang__)
+        extern "C" {
+            unsigned char _addcarry_u8(unsigned char, unsigned char, unsigned char, unsigned char*);
+            unsigned char _addcarry_u16(unsigned char, unsigned short, unsigned short, unsigned short*);
+            unsigned char _subborrow_u8(unsigned char, unsigned char, unsigned char, unsigned char*);
+            unsigned char _subborrow_u16(unsigned char, unsigned short, unsigned short, unsigned short*);
+        }
+    #endif
 
 namespace slim
 {


### PR DESCRIPTION
Such code can be compiled in clang wsl:
```bash
[/mnt/d/Programming/C++]$ cat test.cpp
#include <slimcpplib/long_int.h>
#include <slimcpplib/long_io.h>

using namespace slim::literals;

int main() {
        const slim::int256_t u = -10000_si256 << 100;
        std::cout << u << std::endl;
}
[/mnt/d/Programming/C++]$ clang++ test.cpp -std=c++20 -I slimcpplib/include
[/mnt/d/Programming/C++]$ ./a.out
-12676506002282294014967032053760000
[/mnt/d/Programming/C++]$
```
But msvc clang doesn't find intrinsics for compilation:
```bash
PS D:\Programming\C++> cat .\test.cpp
#include <slimcpplib/long_int.h>
#include <slimcpplib/long_io.h>

using namespace slim::literals;

int main() {
        const slim::int256_t u = -10000_si256 << 100;
        std::cout << u << std::endl;
}
PS D:\Programming\C++> clang++ .\test.cpp -std=c++20 -I .\slimcpplib\include
In file included from .\test.cpp:1:
In file included from .\slimcpplib\include\slimcpplib/long_int.h:39:
In file included from .\slimcpplib\include\slimcpplib\long_uint.h:35:
In file included from .\slimcpplib\include\slimcpplib\long_math_long.h:42:
.\slimcpplib\include\slimcpplib\long_math_msvc.h:231:12: error: use of undeclared identifier '_addcarry_u8'
  231 |     return _addcarry_u8(0, value1, value2, &value1);
      |            ^~~~~~~~~~~~
.\slimcpplib\include\slimcpplib\long_math_msvc.h:239:12: error: use of undeclared identifier '_addcarry_u16'
  239 |     return _addcarry_u16(0, value1, value2, &value1);
      |            ^~~~~~~~~~~~~
.\slimcpplib\include\slimcpplib\long_math_msvc.h:267:12: error: use of undeclared identifier '_addcarry_u8'
  267 |     return _addcarry_u8(carry, value1, value2, &value1);
      |            ^~~~~~~~~~~~
.\slimcpplib\include\slimcpplib\long_math_msvc.h:274:12: error: use of undeclared identifier '_addcarry_u16'
  274 |     return _addcarry_u16(carry, value1, value2, &value1);
      |            ^~~~~~~~~~~~~
.\slimcpplib\include\slimcpplib\long_math_msvc.h:322:12: error: use of undeclared identifier '_subborrow_u8'
  322 |     return _subborrow_u8(0, value1, value2, &value1);
      |            ^~~~~~~~~~~~~
.\slimcpplib\include\slimcpplib\long_math_msvc.h:330:12: error: use of undeclared identifier '_subborrow_u16'
  330 |     return _subborrow_u16(0, value1, value2, &value1);
      |            ^~~~~~~~~~~~~~
.\slimcpplib\include\slimcpplib\long_math_msvc.h:358:12: error: use of undeclared identifier '_subborrow_u8'
  358 |     return _subborrow_u8(borrow, value1, value2, &value1);
      |            ^~~~~~~~~~~~~
.\slimcpplib\include\slimcpplib\long_math_msvc.h:366:12: error: use of undeclared identifier '_subborrow_u16'
  366 |     return _subborrow_u16(static_cast<uint8_t>(borrow), value1, value2, &value1);
      |            ^~~~~~~~~~~~~~
In file included from .\test.cpp:1:
In file included from .\slimcpplib\include\slimcpplib/long_int.h:39:
.\slimcpplib\include\slimcpplib\long_uint.h:1032:32: warning: identifier '_ui128' preceded by whitespace in a literal
      operator declaration is deprecated [-Wdeprecated-literal-operator]
 1032 | constexpr uint128_t operator"" _ui128() noexcept
      |                     ~~~~~~~~~~~^~~~~~
      |                     operator""_ui128
.\slimcpplib\include\slimcpplib\long_uint.h:1038:32: warning: identifier '_ui256' preceded by whitespace in a literal
      operator declaration is deprecated [-Wdeprecated-literal-operator]
 1038 | constexpr uint256_t operator"" _ui256() noexcept
      |                     ~~~~~~~~~~~^~~~~~
      |                     operator""_ui256
In file included from .\test.cpp:1:
.\slimcpplib\include\slimcpplib/long_int.h:590:31: warning: identifier '_si128' preceded by whitespace in a literal
      operator declaration is deprecated [-Wdeprecated-literal-operator]
  590 | constexpr int128_t operator"" _si128() noexcept
      |                    ~~~~~~~~~~~^~~~~~
      |                    operator""_si128
.\slimcpplib\include\slimcpplib/long_int.h:596:31: warning: identifier '_si256' preceded by whitespace in a literal
      operator declaration is deprecated [-Wdeprecated-literal-operator]
  596 | constexpr int256_t operator"" _si256() noexcept
      |                    ~~~~~~~~~~~^~~~~~
      |                    operator""_si256
4 warnings and 8 errors generated.
PS D:\Programming\C++>